### PR TITLE
add inclusion of cassert for GNU compiler

### DIFF
--- a/src/lazy/uftree.cpp
+++ b/src/lazy/uftree.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "uftree.hpp"
 
 using namespace std;


### PR DESCRIPTION
kgotoさんが指摘されたようにGNUでコンパイルできなかったので、`#include <cassert>`を追加しました。